### PR TITLE
docs: document release repo setup and gnutar removal

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -106,11 +106,9 @@ nix:
       description: "Go Version Manager (govm) simplifies the management of Go installations."
       license: "asl20"
 
-      # Mapped from the 'Requirements' section in README.md
+      # Runtime dependency for extraction during install/update
       dependencies:
-          - curl
           - gnutar
-          - gnused
 
       repository:
           owner: sbonaiva

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,28 +9,110 @@
 version: 2
 
 before:
-  hooks:
-    - go mod tidy
+    hooks:
+        - go mod tidy
 
 builds:
-  - main: ./cmd/govm
-    binary: govm
-    ldflags: "-s -w -X main.Version={{.Env.VERSION}}"
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
+    - main: ./cmd/govm
+      binary: govm
+      ldflags: "-s -w -X main.Version={{.Env.VERSION}}"
+      env:
+          - CGO_ENABLED=0
+      goos:
+          - linux
+          - darwin
+          - windows
 
 archives:
-  - formats: [ 'tar.gz' ]
+    - formats: ["tar.gz"]
 
 snapshot:
-  version_template: "{{ .Env.VERSION }}"
+    version_template: "{{ .Env.VERSION }}"
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+    sort: asc
+    filters:
+        exclude:
+            - "^docs:"
+            - "^test:"
+
+winget:
+    - name: govm
+      publisher: Sandro Bonaiva
+      short_description: "Go Version Manager (govm) simplifies the management of Go installations."
+      license: "Apache-2.0"
+      publisher_url: https://github.com/sbonaiva
+      publisher_support_url: "https://github.com/sbonaiva/govm/issues"
+      package_identifier: sbonaiva.govm
+
+      # URL template for downloading the release artifacts from GitHub
+      url_template: "https://github.com/sbonaiva/govm/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+      commit_msg_template: "{{ .PackageIdentifier }}: {{ .Tag }}"
+      homepage: "https://github.com/sbonaiva/govm"
+
+      description: |
+          Go Version Manager (govm) is a command-line tool written in Go that simplifies
+          the management of Go installations on your machine. With a few simple commands,
+          you can easily list, install, and uninstall different versions of the Go
+          programming language.
+
+      license_url: "https://github.com/sbonaiva/govm/blob/main/LICENSE.md"
+      copyright: "Sandro Bonaiva"
+      copyright_url: "https://github.com/sbonaiva/govm/blob/main/LICENSE.md"
+
+      release_notes: "{{.Changelog}}"
+      release_notes_url: "https://github.com/sbonaiva/govm/releases/tag/{{.Tag}}"
+
+      tags:
+          - golang
+          - cli
+          - go
+          - version-manager
+
+      repository:
+          owner: sbonaiva
+          name: winget-pkgs # Assuming you will host the manifest in a 'winget-pkgs' repo
+          branch: main
+
+homebrew_casks:
+    - name: govm
+      description: "Go Version Manager (govm) simplifies the management of Go installations."
+      homepage: "https://github.com/sbonaiva/govm"
+
+      binaries:
+          - govm
+
+      url:
+          template: "https://github.com/sbonaiva/govm/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+      # Cleanup instructions for when the user uninstalls the cask
+      zap:
+          trash:
+              - "~/.govm"
+
+      repository:
+          owner: sbonaiva
+          name: homebrew-tap
+          branch: main
+
+      commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
+
+nix:
+    - name: govm
+      url_template: "https://github.com/sbonaiva/govm/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+      commit_msg_template: "{{ .ProjectName }}: {{ .Tag }}"
+      homepage: "https://github.com/sbonaiva/govm"
+      description: "Go Version Manager (govm) simplifies the management of Go installations."
+      license: "asl20"
+
+      # Mapped from the 'Requirements' section in README.md
+      dependencies:
+          - curl
+          - gnutar
+          - gnused
+
+      repository:
+          owner: sbonaiva
+          name: nixpkgs
+          branch: main

--- a/README.md
+++ b/README.md
@@ -33,6 +33,36 @@ cd govm
 make install
 ```
 
+## Package manager publishing (GoReleaser)
+
+GoReleaser is configured to open PRs to the repositories below. Create them
+before running a release so the automation can push updates.
+
+### Winget
+
+- Create `sbonaiva/winget-pkgs` on GitHub.
+- Set the default branch to `main`.
+- Provide a token with repo write permissions to GoReleaser.
+
+### Homebrew Cask
+
+- Create `sbonaiva/homebrew-tap` on GitHub.
+- Set the default branch to `main`.
+- Provide a token with repo write permissions to GoReleaser.
+
+### Nix
+
+- Fork `NixOS/nixpkgs` to `sbonaiva/nixpkgs`.
+- Set the default branch to `main`.
+- Provide a token with repo write permissions to GoReleaser.
+
+## Removing GNU tar (optional)
+
+`govm` currently shells out to `tar` when extracting Go toolchain archives.
+If you want to remove the runtime dependency on GNU tar, replace the external
+`tar` call with Go-native extraction using `archive/tar` and `compress/gzip`,
+then drop `gnutar` from the Nix package dependencies.
+
 ## Usage
 
 ### List


### PR DESCRIPTION
Body:

  ## Summary

  - Document the package-manager repos required by GoReleaser.
  - Add steps for creating each repo (winget, homebrew tap, nixpkgs fork).
  - Explain how to remove the gnutar runtime dependency.

  ## Why

  GoReleaser is configured to open PRs for winget, Homebrew Cask, and Nix. Users need a clear, repeatable setup to create the target repos
  and (optionally) avoid a runtime dependency on external tar.

  ## Repo setup (required for GoReleaser PRs)

  ### Winget

  - Create sbonaiva/winget-pkgs.
  - Default branch must be main.
  - Ensure GoReleaser has a token with repo write permissions.

  ### Homebrew Cask

  - Create sbonaiva/homebrew-tap.
  - Default branch must be main.
  - Ensure GoReleaser has a token with repo write permissions.

  ### Nix

  - Fork [nix-community/nur-packages-template](https://github.com/nix-community/nur-packages-template) to sbonaiva/nixpkgs.
  - Default branch must be main.
  - Ensure GoReleaser has a token with repo write permissions.
  
  When stuck on Nix use this link https://github.com/nix-community/NUR?tab=readme-ov-file#how-to-add-your-own-repository